### PR TITLE
Remove staging channel 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40


### PR DESCRIPTION
python-docx 1.2.0

**Destination channel:** defaults

### Links

- [PKG-13342](https://anaconda.atlassian.net/browse/PKG-13342)
- [Upstream repository](https://github.com/python-openxml/python-docx)

### Explanation of changes:

- Remove `abs.yaml` that was routing builds to staging channel `sfe1ed40` instead of pkgs/main
- python-docx 1.2.0 recipe was merged in PR #3 but never released to defaults due to this misconfigured upload channel
- Pure Python package doesn't need abs.yaml
- Blocker for pdf2docx (PKG-13146) which depends on python-docx

[PKG-13342]: https://anaconda.atlassian.net/browse/PKG-13342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ