### PR TITLE
Bump build number to trigger release to pkgs/main

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
python-docx 1.2.0

**Destination channel:** defaults

### Links

- [PKG-13342](https://anaconda.atlassian.net/browse/PKG-13342)

### Explanation of changes:

- Bump build number to 1 to trigger PBP release graph (PR #4 only deleted abs.yaml, no meta.yaml change)
- Blocker for pdf2docx (PKG-13146)

[PKG-13342]: https://anaconda.atlassian.net/browse/PKG-13342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ